### PR TITLE
Port Vietnamese Normalizer to Rust and Optimize Pipeline

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -18,6 +18,21 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c08606f8c3cbf4ce6ec8e28fb0014a2c086708fe954eaa885384a6165172e7e8"
 
 [[package]]
+name = "bit-set"
+version = "0.5.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0700ddab506f33b20a03b13996eccd309a48e5ff77d0d95926aa0210fb4e95f1"
+dependencies = [
+ "bit-vec",
+]
+
+[[package]]
+name = "bit-vec"
+version = "0.6.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "349f9b6a179ed607305526ca489b34ad0a41aed5f7980fa90eb03160b69598fb"
+
+[[package]]
 name = "cc"
 version = "1.2.56"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -32,6 +47,17 @@ name = "cfg-if"
 version = "1.0.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9330f8b2ff13f34540b44e946ef35111825727b38d33286ef986142615121801"
+
+[[package]]
+name = "fancy-regex"
+version = "0.13.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "531e46835a22af56d1e3b66f04844bed63158bc094a628bec1d321d9b4c44bf2"
+dependencies = [
+ "bit-set",
+ "regex-automata",
+ "regex-syntax",
+]
 
 [[package]]
 name = "find-msvc-tools"
@@ -226,6 +252,8 @@ checksum = "b39cdef0fa800fc44525c84ccb54a029961a8215f9619753635a9c0d2538d46d"
 name = "sea-g2p-rs"
 version = "0.1.0"
 dependencies = [
+ "aho-corasick",
+ "fancy-regex",
  "memmap2",
  "once_cell",
  "pyo3",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -13,6 +13,8 @@ regex = "1.10"
 once_cell = "1.19"
 memmap2 = "0.9"
 unicode-normalization = "0.1"
+aho-corasick = "1.1"
+fancy-regex = "0.13"
 
 [build-dependencies]
 pyo3-build-config = "0.23"

--- a/debug_norm.py
+++ b/debug_norm.py
@@ -1,0 +1,8 @@
+import sea_g2p_rs
+normalizer = sea_g2p_rs.Normalizer()
+text = "RAM hệ thống là 128GB DDR5-6400."
+print(f"Input: {text}")
+print(f"Output: {normalizer.normalize(text)}")
+text2 = "1,299"
+print(f"Input: {text2}")
+print(f"Output: {normalizer.normalize(text2)}")

--- a/debug_norm_v2.py
+++ b/debug_norm_v2.py
@@ -1,0 +1,5 @@
+import sea_g2p_rs
+normalizer = sea_g2p_rs.Normalizer()
+text = "RAM hệ thống là 128GB DDR5-6400."
+print(f"Input: {text}")
+print(f"Output: '{normalizer.normalize(text)}'")

--- a/debug_rust.py
+++ b/debug_rust.py
@@ -1,0 +1,17 @@
+import sea_g2p.sea_g2p_rs as sea_g2p_rs
+n = sea_g2p_rs.Normalizer()
+text = "RAM hệ thống là 128GB DDR5-6400."
+print(f"Input: {text}")
+print(f"Output: {n.normalize(text)}")
+
+text2 = "1,299"
+print(f"Input: {text2}")
+print(f"Output: {n.normalize(text2)}")
+
+text3 = "Độ pH của nước là 7."
+print(f"Input: {text3}")
+print(f"Output: {n.normalize(text3)}")
+
+text4 = "1.5×10^-3"
+print(f"Input: {text4}")
+print(f"Output: {n.normalize(text4)}")

--- a/python/sea_g2p/normalizer.py
+++ b/python/sea_g2p/normalizer.py
@@ -1,50 +1,27 @@
-import re
-import unicodedata
-from .cleaner import clean_vietnamese_text
+import logging
+from .sea_g2p_rs import Normalizer as _RustNormalizer
 
 class Normalizer:
     """
     A text normalizer for Vietnamese Text-to-Speech systems.
     Converts numbers, dates, units, and special characters into readable Vietnamese text.
+    Uses a fast Rust core for high performance.
     """
     
     def __init__(self, lang: str = "vi") -> None:
         self.lang = lang
         if lang != "vi":
-            import logging
-            logging.getLogger("sea_g2p.Normalizer").warning(f"Language '{lang}' is not fully supported for normalization yet. Falling back to 'vi'.")
+            logging.getLogger("sea_g2p.Normalizer").warning(
+                f"Language '{lang}' is not fully supported for normalization yet. Falling back to 'vi'."
+            )
+        try:
+            self._rust_normalizer = _RustNormalizer()
+        except Exception as e:
+            logging.getLogger("sea_g2p.Normalizer").error(f"Failed to initialize Rust normalizer: {e}")
+            raise
     
     def normalize(self, text: str) -> str:
-        """Main normalization pipeline with EN tag protection."""
+        """Main normalization pipeline powered by Rust."""
         if not text:
             return ""
-
-        # Pre-normalization: Ensure NFC format for Vietnamese characters
-        text = unicodedata.normalize('NFC', text)
-
-        # Step 1: Detect and protect EN tags
-        en_contents = []
-        placeholder_pattern = "ENTOKEN{}"
-        
-        def extract_en(match):
-            en_contents.append(match.group(0))
-            return placeholder_pattern.format(len(en_contents) - 1)
-        
-        text = re.sub(r'<en>.*?</en>', extract_en, text, flags=re.IGNORECASE)
-        
-        # Step 2: Core Normalization
-        text = clean_vietnamese_text(text)
-        
-        # Final cleanup - preserve newlines
-        text = text.lower()
-        text = re.sub(r'[ \t\xA0]+', ' ', text).strip()
-        
-        # Step 3: Restore EN tags
-        for idx, en_content in enumerate(en_contents):
-            placeholder = placeholder_pattern.format(idx).lower()
-            text = text.replace(placeholder, en_content)
-        
-        # Final whitespace cleanup - preserve newlines
-        text = re.sub(r'[ \t\xA0]+', ' ', text).strip()
-        
-        return text
+        return self._rust_normalizer.normalize(text)

--- a/python/sea_g2p/pipeline.py
+++ b/python/sea_g2p/pipeline.py
@@ -9,9 +9,9 @@ class SEAPipeline:
     def run(self, text: str) -> str:
         """
         Run the full text-to-phoneme pipeline: normalization followed by phonemization.
+        This call is optimized to run entirely in Rust to reduce cross-language overhead.
         """
         if not text:
             return ""
-        normalized_text = self.normalizer.normalize(text)
-        phonemes = self.g2p.convert(normalized_text)
-        return phonemes
+        # The G2P class already uses the Rust engine, and we've added a unified run_pipeline method
+        return self.g2p._rust_engine.run_pipeline(text)

--- a/reproduce_khong.py
+++ b/reproduce_khong.py
@@ -1,0 +1,5 @@
+import sea_g2p_rs
+normalizer = sea_g2p_rs.Normalizer()
+text = "128GB DDR5"
+print(f"Input: {text}")
+print(f"Output: '{normalizer.normalize(text)}'")

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,9 +1,11 @@
 use pyo3::prelude::*;
 pub mod g2p;
+pub mod normalizer;
 
 #[pyclass]
 struct G2P {
     engine: g2p::G2PEngine,
+    normalizer: normalizer::Normalizer,
 }
 
 #[pymethods]
@@ -12,7 +14,8 @@ impl G2P {
     fn new(dict_path: &str) -> PyResult<Self> {
         let engine = g2p::G2PEngine::new(dict_path)
             .map_err(|e| pyo3::exceptions::PyIOError::new_err(e.to_string()))?;
-        Ok(G2P { engine })
+        let normalizer = normalizer::Normalizer::new();
+        Ok(G2P { engine, normalizer })
     }
 
     fn phonemize(&self, text: &str) -> PyResult<String> {
@@ -22,11 +25,38 @@ impl G2P {
     fn phonemize_batch(&self, texts: Vec<String>) -> PyResult<Vec<String>> {
         Ok(texts.into_iter().map(|t| self.engine.phonemize(&t)).collect())
     }
+
+    fn normalize(&self, text: &str) -> PyResult<String> {
+        Ok(self.normalizer.normalize(text))
+    }
+
+    fn run_pipeline(&self, text: &str) -> PyResult<String> {
+        let normalized = self.normalizer.normalize(text);
+        Ok(self.engine.phonemize(&normalized))
+    }
+}
+
+#[pyclass]
+struct Normalizer {
+    inner: normalizer::Normalizer,
+}
+
+#[pymethods]
+impl Normalizer {
+    #[new]
+    fn new() -> Self {
+        Normalizer { inner: normalizer::Normalizer::new() }
+    }
+
+    fn normalize(&self, text: &str) -> String {
+        self.inner.normalize(text)
+    }
 }
 
 /// sea_g2p_rs: Rust core for sea-g2p
 #[pymodule]
 fn sea_g2p_rs(m: &Bound<'_, PyModule>) -> PyResult<()> {
     m.add_class::<G2P>()?;
+    m.add_class::<Normalizer>()?;
     Ok(())
 }

--- a/src/normalizer/cleaner.rs
+++ b/src/normalizer/cleaner.rs
@@ -1,0 +1,1240 @@
+use once_cell::sync::Lazy;
+use fancy_regex::{Regex, Captures};
+use std::collections::HashMap;
+use aho_corasick::{AhoCorasick, MatchKind};
+use crate::normalizer::num2vi::{n2w, n2w_single};
+use crate::normalizer::vi_resources::*;
+
+// Regex patterns
+pub static RE_TECHNICAL: Lazy<Regex> = Lazy::new(|| {
+    Regex::new(r"(?ix)
+        \b(?:https?|ftp)://[A-Za-z0-9.\-_~:/?#\[\]@!$&\'()*+,;=]+\b
+        |
+        \b(?:www\.)[A-Za-z0-9.\-_~:/?#\[\]@!$&\'()*+,;=]+\b
+        |
+        \b[A-Za-z0-9.\-]+(?:\.com|\.vn|\.net|\.org|\.gov|\.io|\.biz|\.info)(?:/[A-Za-z0-9.\-_~:/?#\[\]@!$&\'()*+,;=]*)?\b
+        |
+        (?<!\w)/[a-zA-Z0-9._\-/]{2,}\b
+        |
+        \b[a-zA-Z]:\\[a-zA-Z0-9._\\\-]+\b
+        |
+        \b[a-zA-Z0-9._\-]+\.(?:txt|log|tar|gz|zip|sh|py|js|cpp|h|json|xml|yaml|yml|md|csv|pdf|docx|xlsx|exe|dll|so|config)\b
+        |
+        \b[a-zA-Z][a-zA-Z0-9]*(?:[._\-][a-zA-Z0-9]+){2,}\b
+        |
+        \b(?:[a-fA-F0-9]{1,4}:){3,7}[a-fA-F0-9]{1,4}\b
+    ").unwrap()
+});
+
+pub static RE_EMAIL: Lazy<Regex> = Lazy::new(|| {
+    Regex::new(r"(?i)\b[A-Za-z0-9._%+-]+@[A-Za-z0-9.-]+\.[A-Z|a-z]{2,}\b").unwrap()
+});
+
+pub static RE_TECH_SPLIT: Lazy<Regex> = Lazy::new(|| {
+    Regex::new(r"([./:?&=/_ \-\\#])").unwrap()
+});
+
+pub static RE_EMAIL_SPLIT: Lazy<Regex> = Lazy::new(|| {
+    Regex::new(r"([._\-+])").unwrap()
+});
+
+pub static RE_SLASH_NUMBER: Lazy<Regex> = Lazy::new(|| {
+    Regex::new(r"\b(\d+)/(\d+)\b").unwrap()
+});
+
+pub static RE_DOMAIN_SUFFIXES: Lazy<Regex> = Lazy::new(|| {
+    Regex::new(r"(?i)\.(com|vn|net|org|edu|gov|io|biz|info)\b").unwrap()
+});
+
+pub static RE_ALPHANUM_SPLIT: Lazy<Regex> = Lazy::new(|| {
+    Regex::new(r"[a-zA-Z]+|\d+").unwrap()
+});
+
+pub static RE_FULL_DATE: Lazy<Regex> = Lazy::new(|| {
+    Regex::new(r"(?i)\b(\d{1,2})(\/|-|\.)(\d{1,2})(\/|-|\.)(\d{4})\b").unwrap()
+});
+
+pub static RE_DAY_MONTH: Lazy<Regex> = Lazy::new(|| {
+    Regex::new(r"(?i)\b(\d{1,2})(\/|-)(\d{1,2})\b").unwrap()
+});
+
+pub static RE_MONTH_YEAR: Lazy<Regex> = Lazy::new(|| {
+    Regex::new(r"(?i)\b(\d{1,2})(\/|-|\.)(\d{4})\b").unwrap()
+});
+
+pub static RE_FULL_TIME: Lazy<Regex> = Lazy::new(|| {
+    Regex::new(r"(?i)\b(\d+)(g|:|h)(\d{1,2})(p|:|m)(\d{1,2})(?:\s*(giây|s|g))?\b").unwrap()
+});
+
+pub static RE_TIME: Lazy<Regex> = Lazy::new(|| {
+    Regex::new(r"(?i)\b(\d+)(g|:|h)(\d{1,2})(?:\s*(phút|p|m))?\b").unwrap()
+});
+
+pub static RE_REDUNDANT_NGAY: Lazy<Regex> = Lazy::new(|| {
+    Regex::new(r"(?i)\bngày\s+ngày\b").unwrap()
+});
+
+pub static RE_REDUNDANT_THANG: Lazy<Regex> = Lazy::new(|| {
+    Regex::new(r"(?i)\btháng\s+tháng\b").unwrap()
+});
+
+pub static RE_REDUNDANT_NAM: Lazy<Regex> = Lazy::new(|| {
+    Regex::new(r"(?i)\bnăm\s+năm\b").unwrap()
+});
+
+pub static RE_SCIENTIFIC: Lazy<Regex> = Lazy::new(|| {
+    Regex::new(r"(?i)\b(\d+(?:[.,]\d+)?e[+-]?\d+)\b").unwrap()
+});
+
+pub static RE_COMPOUND_UNIT: Lazy<Regex> = Lazy::new(|| {
+    let numeric_p = r"(\d+(?:[.,]\d+)*)";
+    Regex::new(&format!(r"(?i)\b{}?\s*([a-zμµ²³°]+)/([a-zμµ²³°0-9]+)\b", numeric_p)).unwrap()
+});
+
+pub static RE_CURRENCY_PREFIX_SYMBOL: Lazy<Regex> = Lazy::new(|| {
+    let numeric_p = r"(\d+(?:[.,]\d+)*)";
+    let magnitude_p = r"(?:\s*(tỷ|triệu|nghìn|ngàn))?";
+    Regex::new(&format!(r"(?i)([$€¥£₩])\s*{}{}", numeric_p, magnitude_p)).unwrap()
+});
+
+pub static RE_CURRENCY_SUFFIX_SYMBOL: Lazy<Regex> = Lazy::new(|| {
+    let numeric_p = r"(\d+(?:[.,]\d+)*)";
+    let magnitude_p = r"(?:\s*(tỷ|triệu|nghìn|ngàn))?";
+    Regex::new(&format!(r"(?i){}{}([$€¥£₩])", numeric_p, magnitude_p)).unwrap()
+});
+
+pub static RE_PERCENTAGE: Lazy<Regex> = Lazy::new(|| {
+    let numeric_p = r"(\d+(?:[.,]\d+)*)";
+    Regex::new(&format!(r"(?i){}\s*%", numeric_p)).unwrap()
+});
+
+pub static RE_UNITS_WITH_NUM: Lazy<Regex> = Lazy::new(|| {
+    let numeric_p = r"(\d+(?:[.,]\d+)*)";
+    let magnitude_p = r"(?:\s*(tỷ|triệu|nghìn|ngàn))?";
+    let mut keys: Vec<_> = MEASUREMENT_KEY_VI.keys().cloned().collect();
+    keys.extend(CURRENCY_KEY.keys().filter(|k| k.as_str() != "%").cloned());
+    keys.sort_by_key(|k| std::cmp::Reverse(k.len()));
+    let units_pattern = keys.iter().map(|k| regex::escape(k)).collect::<Vec<_>>().join("|");
+    Regex::new(&format!(r"(?i)(?<![\d.,]){}{}\s*({})\b", numeric_p, magnitude_p, units_pattern)).unwrap()
+});
+
+pub static RE_STANDALONE_UNIT: Lazy<Regex> = Lazy::new(|| {
+    let safe_standalone = ["km", "cm", "mm", "kg", "mg", "usd", "vnd", "ph"];
+    let pattern = safe_standalone.iter().map(|&s| regex::escape(s)).collect::<Vec<_>>().join("|");
+    Regex::new(&format!(r"(?i)(?<![\d.,])\b({})\b", pattern)).unwrap()
+});
+
+pub static RE_ROMAN_NUMBER: Lazy<Regex> = Lazy::new(|| {
+    Regex::new(r"\b(?=[IVXLCDM]{2,})M{0,4}(CM|CD|D?C{0,3})(XC|XL|L?X{0,3})(IX|IV|V?I{0,3})\b").unwrap()
+});
+
+pub static RE_LETTER: Lazy<Regex> = Lazy::new(|| {
+    Regex::new(r#"(?i)(chữ|chữ cái|kí tự|ký tự)\s+(['"]?)([a-z])(['"]?)\b"#).unwrap()
+});
+
+pub static RE_STANDALONE_LETTER: Lazy<Regex> = Lazy::new(|| {
+    Regex::new(r"(?<!['’])\b([a-zA-Z])\b(\.?)").unwrap()
+});
+
+pub static RE_SENTENCE_SPLIT: Lazy<Regex> = Lazy::new(|| {
+    Regex::new(r"([.!?]+(?:\s+|$))").unwrap()
+});
+
+pub static RE_ACRONYM: Lazy<Regex> = Lazy::new(|| {
+    Regex::new(r"\b(?=[A-Z0-9]*[A-Z])[A-Z0-9]{2,}\b").unwrap()
+});
+
+pub static RE_ALPHANUMERIC: Lazy<Regex> = Lazy::new(|| {
+    Regex::new(r"\b(\d+)([a-zA-Z])\b").unwrap()
+});
+
+pub static RE_BRACKETS: Lazy<Regex> = Lazy::new(|| {
+    Regex::new(r"[\(\[\{]\s*(.*?)\s*[\)\]\}]").unwrap()
+});
+
+pub static RE_STRIP_BRACKETS: Lazy<Regex> = Lazy::new(|| {
+    Regex::new(r"[\[\]\(\)\{\}]").unwrap()
+});
+
+pub static RE_TEMP_C_NEG: Lazy<Regex> = Lazy::new(|| {
+    Regex::new(r"(?i)-(\d+(?:[.,]\d+)?)\s*°\s*c\b").unwrap()
+});
+
+pub static RE_TEMP_F_NEG: Lazy<Regex> = Lazy::new(|| {
+    Regex::new(r"(?i)-(\d+(?:[.,]\d+)?)\s*°\s*f\b").unwrap()
+});
+
+pub static RE_TEMP_C: Lazy<Regex> = Lazy::new(|| {
+    Regex::new(r"(?i)(\d+(?:[.,]\d+)?)\s*°\s*c\b").unwrap()
+});
+
+pub static RE_TEMP_F: Lazy<Regex> = Lazy::new(|| {
+    Regex::new(r"(?i)(\d+(?:[.,]\d+)?)\s*°\s*f\b").unwrap()
+});
+
+pub static RE_DEGREE: Lazy<Regex> = Lazy::new(|| {
+    Regex::new(r"°").unwrap()
+});
+
+pub static RE_VERSION: Lazy<Regex> = Lazy::new(|| {
+    Regex::new(r"\b(\d+(?:\.\d+)+)\b").unwrap()
+});
+
+pub static RE_CLEAN_OTHERS: Lazy<Regex> = Lazy::new(|| {
+    Regex::new(r"[^a-zA-Z0-9\sàáảãạăắằẳẵặâấầẩẫậèéẻẽẹêếềểễệìíỉĩịòóỏõọôốồổỗộơớờởỡợùúủũụưứừửữựỳýỷỹỵđÀÁẢÃẠĂẮẰẲẴẶÂẤẦẨẪẬÈÉẺẼẸÊẾỀỂỄỆÌÍỈĨỊÒÓỎÕỌÔỐỒỔỖỘƠỚỜỞỠỢÙÚỦŨỤƯỨỪỬỮỰỲÝỶỸỴĐ.,!?_\'’]").unwrap()
+});
+
+pub static RE_CLEAN_QUOTES: Lazy<Regex> = Lazy::new(|| {
+    Regex::new(r#"["“”"]"#).unwrap()
+});
+
+pub static RE_CLEAN_QUOTES_EDGES: Lazy<Regex> = Lazy::new(|| {
+    Regex::new(r"(^|\s)['’]+|['’]+($|\s)").unwrap()
+});
+
+pub static RE_PRIME: Lazy<Regex> = Lazy::new(|| {
+    Regex::new(r"(\b[a-zA-Z0-9])['’](?!\w)").unwrap()
+});
+
+pub static RE_COLON_SEMICOLON: Lazy<Regex> = Lazy::new(|| {
+    Regex::new(r"[:;]").unwrap()
+});
+
+pub static RE_EXTRA_SPACES: Lazy<Regex> = Lazy::new(|| {
+    Regex::new(r"[ \t\xA0]+").unwrap()
+});
+
+pub static RE_EXTRA_COMMAS: Lazy<Regex> = Lazy::new(|| {
+    Regex::new(r",\s*,").unwrap()
+});
+
+pub static RE_COMMA_BEFORE_PUNCT: Lazy<Regex> = Lazy::new(|| {
+    Regex::new(r",\s*([.!?;])").unwrap()
+});
+
+pub static RE_SPACE_BEFORE_PUNCT: Lazy<Regex> = Lazy::new(|| {
+    Regex::new(r"\s+([,.!?;:])").unwrap()
+});
+
+pub static RE_MISSING_SPACE_AFTER_PUNCT: Lazy<Regex> = Lazy::new(|| {
+    Regex::new(r"([.,!?;:])(?=[^\s\d<])").unwrap()
+});
+
+pub static RE_ENTOKEN: Lazy<Regex> = Lazy::new(|| {
+    Regex::new(r"(?i)ENTOKEN\d+").unwrap()
+});
+
+pub static RE_INTERNAL_EN_TAG: Lazy<Regex> = Lazy::new(|| {
+    Regex::new(r"(?i)(__start_en__.*?__end_en__|<en>.*?</en>)").unwrap()
+});
+
+pub static RE_DOT_BETWEEN_DIGITS: Lazy<Regex> = Lazy::new(|| {
+    Regex::new(r"(\d+)\.(\d+)").unwrap()
+});
+
+pub static RE_UNIT_POWERS: Lazy<Regex> = Lazy::new(|| {
+    Regex::new(r"\b([a-zA-Z]+)\^([-+]?\d+)\b").unwrap()
+});
+
+pub static RE_ACRONYMS_EXCEPTIONS: Lazy<Regex> = Lazy::new(|| {
+    let mut keys: Vec<_> = COMBINED_EXCEPTIONS.keys().cloned().collect();
+    keys.sort_by_key(|k| std::cmp::Reverse(k.len()));
+    let pattern = keys.iter().map(|k| format!(r"\b{}\b", regex::escape(k))).collect::<Vec<_>>().join("|");
+    Regex::new(&pattern).unwrap()
+});
+
+pub static RE_ORDINAL: Lazy<Regex> = Lazy::new(|| {
+    Regex::new(r"(?i)(thứ|hạng)(\s+)(\d+)\b").unwrap()
+});
+
+pub static RE_MULTIPLY: Lazy<Regex> = Lazy::new(|| {
+    Regex::new(r"(\d+)(x|\sx\s)(\d+)").unwrap()
+});
+
+pub static RE_PHONE: Lazy<Regex> = Lazy::new(|| {
+    Regex::new(r"((\+84|84|0|0084)(3|5|7|8|9)[0-9]{8})").unwrap()
+});
+
+pub static RE_DOT_SEP: Lazy<Regex> = Lazy::new(|| {
+    Regex::new(r"\d+(\.\d{3})+").unwrap()
+});
+
+pub static RE_NUMBER: Lazy<Regex> = Lazy::new(|| {
+    let num_combined = r"(\d+[,]\d+|\d+(\.\d{3}){1,3}|\d+(\s\d{3}){1,3}|\d+)";
+    Regex::new(&format!(r"(\D)(-)?{}(?!\d)", num_combined)).unwrap()
+});
+
+pub static RE_NUMBER_START: Lazy<Regex> = Lazy::new(|| {
+    let num_combined = r"(\d+[,]\d+|\d+(\.\d{3}){1,3}|\d+(\s\d{3}){1,3}|\d+)";
+    Regex::new(&format!(r"(?m)^(-)?{}(?!\d)", num_combined)).unwrap()
+});
+
+pub static RE_FLOAT_WITH_COMMA: Lazy<Regex> = Lazy::new(|| {
+    Regex::new(r"(?<![\d.])(\d+(?:\.\d{3})*),(\d+)(%)?").unwrap()
+});
+
+pub static RE_MULTI_COMMA: Lazy<Regex> = Lazy::new(|| {
+    Regex::new(r"\b(\d+(?:,\d+){2,})\b").unwrap()
+});
+
+pub static RE_STRIP_DOT_SEP: Lazy<Regex> = Lazy::new(|| {
+    Regex::new(r"(?<![\d.])\d+(?:\.\d{3})+(?![\d.])").unwrap()
+});
+
+pub static RE_POWER_OF_TEN_EXPLICIT: Lazy<Regex> = Lazy::new(|| {
+    Regex::new(r"(?i)\b(\d+(?:[.,]\d+)?)\s*[x*×]\s*10\^([-+]?\d+)\b").unwrap()
+});
+
+pub static RE_POWER_OF_TEN_IMPLICIT: Lazy<Regex> = Lazy::new(|| {
+    Regex::new(r"\b10\^([-+]?\d+)\b").unwrap()
+});
+
+pub static AC_ABBRS: Lazy<(AhoCorasick, Vec<&'static str>)> = Lazy::new(|| {
+    let mut sorted_abbrs: Vec<_> = ABBRS.iter().collect();
+    sorted_abbrs.sort_by_key(|(k, _)| std::cmp::Reverse(k.len()));
+    let keys: Vec<_> = sorted_abbrs.iter().map(|(k, _)| k.as_str()).collect();
+    let values: Vec<_> = sorted_abbrs.iter().map(|(_, &v)| v).collect();
+    let ac = AhoCorasick::builder()
+        .match_kind(MatchKind::LeftmostLongest)
+        .build(&keys)
+        .unwrap();
+    (ac, values)
+});
+
+pub static AC_SYMBOLS: Lazy<(AhoCorasick, Vec<&'static str>)> = Lazy::new(|| {
+    let mut sorted_symbols: Vec<_> = SYMBOLS_MAP.iter().collect();
+    sorted_symbols.sort_by_key(|(k, _)| std::cmp::Reverse(k.to_string().len()));
+    let keys: Vec<_> = sorted_symbols.iter().map(|(k, _)| k.to_string()).collect();
+    let values: Vec<_> = sorted_symbols.iter().map(|(_, &v)| v).collect();
+    let ac = AhoCorasick::builder()
+        .match_kind(MatchKind::LeftmostLongest)
+        .build(&keys)
+        .unwrap();
+    (ac, values)
+});
+
+const DAY_IN_MONTH: [i32; 12] = [31, 29, 31, 30, 31, 30, 31, 31, 30, 31, 30, 31];
+
+fn is_valid_date(day: &str, month: &str) -> bool {
+    let day_val = day.parse::<i32>().unwrap_or(0);
+    let month_val = month.parse::<i32>().unwrap_or(0);
+    month_val >= 1 && month_val <= 12 && day_val >= 1 && day_val <= DAY_IN_MONTH[(month_val - 1) as usize]
+}
+
+pub fn normalize_date(text: &str) -> String {
+    let mut text = RE_FULL_DATE.replace_all(text, |caps: &Captures| {
+        let day = caps.get(1).unwrap().as_str();
+        let month = caps.get(3).unwrap().as_str();
+        let year = caps.get(5).unwrap().as_str();
+        if is_valid_date(day, month) {
+            let m_val = if month.parse::<i32>().unwrap_or(0) == 4 { "tư".to_string() } else { n2w(&month.parse::<i32>().unwrap_or(0).to_string()) };
+            format!("ngày {} tháng {} năm {}", n2w(&day.parse::<i32>().unwrap_or(0).to_string()), m_val, n2w(year))
+        } else {
+            caps.get(0).unwrap().as_str().to_string()
+        }
+    }).to_string();
+
+    text = RE_MONTH_YEAR.replace_all(&text, |caps: &Captures| {
+        let month = caps.get(1).unwrap().as_str();
+        let year = caps.get(3).unwrap().as_str();
+        let m_val = if month.parse::<i32>().unwrap_or(0) == 4 { "tư".to_string() } else { n2w(&month.parse::<i32>().unwrap_or(0).to_string()) };
+        format!("tháng {} năm {}", m_val, n2w(year))
+    }).to_string();
+
+    text = RE_DAY_MONTH.replace_all(&text, |caps: &Captures| {
+        let day = caps.get(1).unwrap().as_str();
+        let month = caps.get(3).unwrap().as_str();
+        if is_valid_date(day, month) {
+            let m_val = if month.parse::<i32>().unwrap_or(0) == 4 { "tư".to_string() } else { n2w(&month.parse::<i32>().unwrap_or(0).to_string()) };
+            format!("ngày {} tháng {}", n2w(&day.parse::<i32>().unwrap_or(0).to_string()), m_val)
+        } else {
+            caps.get(0).unwrap().as_str().to_string()
+        }
+    }).to_string();
+
+    text = RE_REDUNDANT_NGAY.replace_all(&text, "ngày").to_string();
+    text = RE_REDUNDANT_THANG.replace_all(&text, "tháng").to_string();
+    text = RE_REDUNDANT_NAM.replace_all(&text, "năm").to_string();
+    text
+}
+
+fn norm_time_part(s: &str) -> &str {
+    if s == "00" { "0" } else { s }
+}
+
+pub fn normalize_time(text: &str) -> String {
+    let mut text = RE_FULL_TIME.replace_all(text, |caps: &Captures| {
+        let h = caps.get(1).unwrap().as_str();
+        let m = caps.get(3).unwrap().as_str();
+        let s = caps.get(5).unwrap().as_str();
+        format!("{} giờ {} phút {} giây", n2w(norm_time_part(h)), n2w(norm_time_part(m)), n2w(norm_time_part(s)))
+    }).to_string();
+
+    text = RE_TIME.replace_all(&text, |caps: &Captures| {
+        let h = caps.get(1).unwrap().as_str();
+        let sep = caps.get(2).unwrap().as_str();
+        let m = caps.get(3).unwrap().as_str();
+        let h_int = h.parse::<i32>().unwrap_or(0);
+        let m_int = m.parse::<i32>().unwrap_or(0);
+
+        if m_int >= 0 && m_int < 60 {
+            if sep == ":" {
+                if h_int < 24 {
+                    format!("{} giờ {} phút", n2w(norm_time_part(h)), n2w(norm_time_part(m)))
+                } else {
+                    format!("{} phút {} giây", n2w(h), n2w(norm_time_part(m)))
+                }
+            } else {
+                format!("{} giờ {} phút", n2w(norm_time_part(h)), n2w(norm_time_part(m)))
+            }
+        } else {
+            caps.get(0).unwrap().as_str().to_string()
+        }
+    }).to_string();
+
+    text
+}
+
+pub fn expand_scientific(num_str: &str) -> String {
+    let num_lower = num_str.to_lowercase();
+    let e_idx = num_lower.find('e').unwrap();
+    let base = &num_str[..e_idx];
+    let exp = &num_str[e_idx+1..];
+
+    let base_norm = if base.contains('.') {
+        let parts: Vec<&str> = base.split('.').collect();
+        let dec_part = parts[1].trim_end_matches('0');
+        if !dec_part.is_empty() {
+            format!("{} chấm {}", n2w(parts[0]), n2w_single(dec_part))
+        } else {
+            n2w(parts[0])
+        }
+    } else if base.contains(',') {
+        let parts: Vec<&str> = base.split(',').collect();
+        let dec_part = parts[1].trim_end_matches('0');
+        if !dec_part.is_empty() {
+            format!("{} phẩy {}", n2w(parts[0]), n2w_single(dec_part))
+        } else {
+            n2w(parts[0])
+        }
+    } else {
+        n2w(&base.replace(',', "").replace('.', ""))
+    };
+
+    let exp_val = exp.trim_start_matches('+');
+    let exp_norm = if exp_val.starts_with('-') {
+        format!("trừ {}", n2w(&exp_val[1..]))
+    } else {
+        n2w(exp_val)
+    };
+    format!("{} nhân mười mũ {}", base_norm, exp_norm)
+}
+
+pub fn expand_number_with_sep(num_str: &str) -> String {
+    if num_str.is_empty() { return String::new(); }
+    if num_str.to_lowercase().contains('e') { return expand_scientific(num_str); }
+
+    if num_str.contains(',') && num_str.contains('.') {
+        let (p0, p1) = if num_str.rfind('.').unwrap() > num_str.rfind(',').unwrap() {
+            let s = num_str.replace(',', "");
+            let idx = s.rfind('.').unwrap();
+            let p1 = s[idx + 1..].to_string();
+            let p0 = s[..idx].to_string();
+            (p0, p1)
+        } else {
+            let s = num_str.replace('.', "");
+            let idx = s.rfind(',').unwrap();
+            let p1 = s[idx + 1..].to_string();
+            let p0 = s[..idx].to_string();
+            (p0, p1)
+        };
+        let dec_part = p1.trim_end_matches('0');
+        if dec_part.is_empty() { return n2w(&p0); }
+        return format!("{} phẩy {}", n2w(&p0), n2w_single(dec_part));
+    }
+
+    if num_str.contains(',') || num_str.contains('.') {
+        let sep = if num_str.contains(',') { ',' } else { '.' };
+        let parts: Vec<&str> = num_str.split(sep).collect();
+        if parts.len() > 2 {
+            return n2w(&num_str.replace(sep, ""));
+        }
+        if parts.len() == 2 {
+            if sep == '.' && parts[1].len() == 3 {
+                 return n2w(&num_str.replace(sep, ""));
+            }
+            // For single comma, favor decimal (phẩy)
+            let dec_part = parts[1].trim_end_matches('0');
+            if dec_part.is_empty() { return n2w(parts[0]); }
+            let sep_word = if sep == ',' { "phẩy" } else { "chấm" };
+            return format!("{} {} {}", n2w(parts[0]), sep_word, n2w_single(dec_part));
+        }
+    }
+
+    n2w(num_str)
+}
+
+pub fn expand_measurement_currency(text: &str) -> String {
+    let mut text = RE_UNITS_WITH_NUM.replace_all(text, |caps: &Captures| {
+        let num = caps.get(1).unwrap().as_str();
+        let mag = caps.get(2).map_or("", |m| m.as_str());
+        let unit = caps.get(3).unwrap().as_str();
+
+        let full = match unit {
+            "M" => "triệu",
+            "m" => "mét",
+            _ => MEASUREMENT_KEY_VI.get(unit.to_lowercase().as_str())
+                    .or_else(|| CURRENCY_KEY.get(unit.to_lowercase().as_str()))
+                    .unwrap_or(&unit),
+        };
+        format!("{} {} {}", expand_number_with_sep(num), mag, full).replace("  ", " ").trim().to_string()
+    }).to_string();
+
+    text = RE_STANDALONE_UNIT.replace_all(&text, |caps: &Captures| {
+        let unit = caps.get(1).unwrap().as_str();
+        let unit_low = unit.to_lowercase();
+        format!(" {} ", MEASUREMENT_KEY_VI.get(unit_low.as_str()).or_else(|| CURRENCY_KEY.get(unit_low.as_str())).unwrap_or(&unit))
+    }).to_string();
+
+    text = RE_CURRENCY_PREFIX_SYMBOL.replace_all(&text, |caps: &Captures| {
+        let symbol = caps.get(1).unwrap().as_str();
+        let num = caps.get(2).unwrap().as_str();
+        let mag = caps.get(3).map_or("", |m| m.as_str());
+        let full = CURRENCY_SYMBOL_MAP.get(symbol).unwrap_or(&"");
+        format!("{} {} {}", expand_number_with_sep(num), mag, full).replace("  ", " ").trim().to_string()
+    }).to_string();
+
+    text = RE_CURRENCY_SUFFIX_SYMBOL.replace_all(&text, |caps: &Captures| {
+        let num = caps.get(1).unwrap().as_str();
+        let mag = caps.get(2).map_or("", |m| m.as_str());
+        let symbol = caps.get(3).unwrap().as_str();
+        let full = CURRENCY_SYMBOL_MAP.get(symbol).unwrap_or(&"");
+        format!("{} {} {}", expand_number_with_sep(num), mag, full).replace("  ", " ").trim().to_string()
+    }).to_string();
+
+    text = RE_PERCENTAGE.replace_all(&text, |caps: &Captures| {
+        format!("{} phần trăm", expand_number_with_sep(caps.get(1).unwrap().as_str()))
+    }).to_string();
+
+    text
+}
+
+pub fn expand_compound_units(text: &str) -> String {
+    RE_COMPOUND_UNIT.replace_all(text, |caps: &Captures| {
+        let num_str = caps.get(1).map_or("", |m| m.as_str());
+        if num_str.is_empty() { return caps.get(0).unwrap().as_str().to_string(); }
+
+        let num = expand_number_with_sep(num_str);
+        let u1_raw = caps.get(2).unwrap().as_str();
+        let u2_raw = caps.get(3).unwrap().as_str();
+
+        fn get_unit(u_raw: &str) -> &str {
+            match u_raw {
+                "M" => "triệu",
+                "m" => "mét",
+                _ => MEASUREMENT_KEY_VI.get(u_raw.to_lowercase().as_str())
+                        .or_else(|| CURRENCY_KEY.get(u_raw.to_lowercase().as_str()))
+                        .unwrap_or(&u_raw),
+            }
+        }
+
+        format!("{} {} trên {}", num, get_unit(u1_raw), get_unit(u2_raw))
+    }).to_string()
+}
+
+pub fn expand_roman(text: &str) -> String {
+    RE_ROMAN_NUMBER.replace_all(text, |caps: &Captures| {
+        let num = caps.get(0).unwrap().as_str().to_uppercase();
+        let mut result = 0;
+        let chars: Vec<char> = num.chars().collect();
+        for i in 0..chars.len() {
+            let val = *ROMAN_NUMERALS.get(&chars[i]).unwrap();
+            if i + 1 < chars.len() && val < *ROMAN_NUMERALS.get(&chars[i+1]).unwrap() {
+                result -= val;
+            } else {
+                result += val;
+            }
+        }
+        format!(" {} ", n2w(&result.to_string()))
+    }).to_string()
+}
+
+pub fn expand_unit_powers(text: &str) -> String {
+    RE_UNIT_POWERS.replace_all(text, |caps: &Captures| {
+        let base = caps.get(1).unwrap().as_str();
+        let power = caps.get(2).unwrap().as_str();
+        let power_norm = if power.starts_with('-') {
+            format!("trừ {}", n2w(&power[1..]))
+        } else {
+            n2w(&power.replace('+', ""))
+        };
+        let base_lower = base.to_lowercase();
+        let full_base = MEASUREMENT_KEY_VI.get(base_lower.as_str())
+            .or_else(|| CURRENCY_KEY.get(base_lower.as_str()))
+            .cloned()
+            .unwrap_or(base);
+        format!(" {} mũ {} ", full_base, power_norm)
+    }).to_string()
+}
+
+pub fn expand_abbreviations(text: &str) -> String {
+    let (ac, values) = &*AC_ABBRS;
+    ac.replace_all(text, values)
+}
+
+pub fn expand_symbols(text: &str) -> String {
+    let (ac, values) = &*AC_SYMBOLS;
+    ac.replace_all(text, values)
+}
+
+pub fn normalize_acronyms(text: &str) -> String {
+    let mut result = Vec::new();
+    // Re-implementing split because RE_SENTENCE_SPLIT might not work as expected with split
+    let mut split_parts = Vec::new();
+    let mut last_pos = 0;
+    for mat in RE_SENTENCE_SPLIT.find_iter(text) {
+        let mat = mat.unwrap();
+        split_parts.push(text[last_pos..mat.start()].to_string());
+        split_parts.push(mat.as_str().to_string());
+        last_pos = mat.end();
+    }
+    if last_pos < text.len() {
+        split_parts.push(text[last_pos..].to_string());
+    }
+
+    for i in (0..split_parts.len()).step_by(2) {
+        let s = &split_parts[i];
+        let sep = if i + 1 < split_parts.len() { &split_parts[i+1] } else { "" };
+        if s.is_empty() {
+            result.push(sep.to_string());
+            continue;
+        }
+
+        let words: Vec<&str> = s.split_whitespace().collect();
+        let alpha_words: Vec<&str> = words.iter().filter(|w| w.chars().any(|c: char| c.is_alphabetic())).cloned().collect();
+        let is_all_caps = !alpha_words.is_empty() && alpha_words.iter().all(|w| w.chars().all(|c: char| c.is_uppercase()));
+
+        if !is_all_caps {
+            let processed_s = RE_ACRONYM.replace_all(s, |caps: &Captures| {
+                let word = caps.get(0).unwrap().as_str();
+                if word.chars().all(|c: char| c.is_ascii_digit()) { return word.to_string(); }
+                if WORD_LIKE_ACRONYMS.contains(word) {
+                    return format!("__start_en__{}__end_en__", word.to_lowercase());
+                }
+                if word.chars().any(|c: char| c.is_ascii_digit()) {
+                    let res: Vec<String> = word.to_lowercase().chars().map(|c: char| {
+                        if c.is_ascii_digit() { n2w_single(&c.to_string()) }
+                        else { (*VI_LETTER_NAMES.get(c.to_string().as_str()).unwrap_or(&c.to_string().as_str())).to_string() }
+                    }).collect();
+                    return res.join(" ");
+                }
+                let spaced_word: String = word.chars().filter(|c: &char| c.is_alphanumeric()).map(|c: char| c.to_lowercase().to_string()).collect::<Vec<_>>().join(" ");
+                if !spaced_word.is_empty() {
+                    format!("__start_en__{}__end_en__", spaced_word)
+                } else {
+                    word.to_string()
+                }
+            }).to_string();
+            result.push(format!("{}{}", processed_s, sep));
+        } else {
+            result.push(format!("{}{}", s, sep));
+        }
+    }
+    result.join("")
+}
+
+pub fn expand_standalone_letters(text: &str) -> String {
+    RE_STANDALONE_LETTER.replace_all(text, |caps: &Captures| {
+        let char_raw = caps.get(1).unwrap().as_str();
+        let char_low = char_raw.to_lowercase();
+        let dot = caps.get(2).map_or("", |m| m.as_str());
+        if let Some(&name) = VI_LETTER_NAMES.get(char_low.as_str()) {
+            if char_raw.chars().next().unwrap().is_uppercase() && dot == "." {
+                format!(" {} ", name)
+            } else {
+                format!(" {}{} ", name, dot)
+            }
+        } else {
+            caps.get(0).unwrap().as_str().to_string()
+        }
+    }).to_string()
+}
+
+pub fn expand_alphanumeric(text: &str) -> String {
+    RE_ALPHANUMERIC.replace_all(text, |caps: &Captures| {
+        let num = caps.get(1).unwrap().as_str();
+        let char_low = caps.get(2).unwrap().as_str().to_lowercase();
+        if let Some(&name) = VI_LETTER_NAMES.get(char_low.as_str()) {
+            let mut pronunciation = name.to_string();
+            if char_low == "d" && (text.to_lowercase().contains("quốc lộ") || text.to_lowercase().contains("ql")) {
+                pronunciation = "đê".to_string();
+            }
+            format!("{} {}", num, pronunciation)
+        } else {
+            caps.get(0).unwrap().as_str().to_string()
+        }
+    }).to_string()
+}
+
+pub fn expand_prime(text: &str) -> String {
+    RE_PRIME.replace_all(text, |caps: &Captures| {
+        let val = caps.get(1).unwrap().as_str().to_lowercase();
+        let pron = if val.chars().all(|c: char| c.is_ascii_digit()) {
+            n2w_single(&val)
+        } else {
+            (*VI_LETTER_NAMES.get(val.as_str()).unwrap_or(&val.as_str())).to_string()
+        };
+        format!("{} phẩy", pron)
+    }).to_string()
+}
+
+pub fn expand_temperatures(text: &str) -> String {
+    let mut text = RE_TEMP_C_NEG.replace_all(text, "âm $1 độ xê").to_string();
+    text = RE_TEMP_F_NEG.replace_all(&text, "âm $1 độ ép").to_string();
+    text = RE_TEMP_C.replace_all(&text, "$1 độ xê").to_string();
+    text = RE_TEMP_F.replace_all(&text, "$1 độ ép").to_string();
+    RE_DEGREE.replace_all(&text, " độ ").to_string()
+}
+
+pub fn num_to_words(number: &str, negative: bool) -> String {
+    let mut num = number.to_string();
+    if RE_DOT_SEP.is_match(&num).unwrap_or(false) {
+        num = num.replace(".", "");
+    }
+    num = num.replace(" ", "");
+
+    if num.contains(',') {
+        let parts: Vec<&str> = num.split(',').collect();
+        if num.matches(',').count() == 1 {
+            // In Vietnamese context for these tests, single comma is often decimal
+            // 1,299 -> "một phẩy hai chín chín"
+            return format!("{} phẩy {}", n2w(parts[0]), n2w_single(parts[1]));
+        }
+        return n2w(&num.replace(',', ""));
+    }
+
+    if negative {
+        format!("âm {}", n2w(&num))
+    } else {
+        n2w(&num)
+    }
+}
+
+pub fn normalize_number_vi(text: &str) -> String {
+    let mut text_mut = RE_ORDINAL.replace_all(text, |caps: &Captures| {
+        let prefix = caps.get(1).unwrap().as_str();
+        let space = caps.get(2).unwrap().as_str();
+        let num = caps.get(3).unwrap().as_str();
+        if num == "1" { format!("{}{}nhất", prefix, space) }
+        else if num == "4" { format!("{}{}tư", prefix, space) }
+        else { format!("{}{}{}", prefix, space, n2w(num)) }
+    }).to_string();
+
+    text_mut = RE_MULTIPLY.replace_all(&text_mut, |caps: &Captures| {
+        format!("{} nhân {}", n2w(caps.get(1).unwrap().as_str()), n2w(caps.get(3).unwrap().as_str()))
+    }).to_string();
+
+    text_mut = RE_PHONE.replace_all(&text_mut, |caps: &Captures| {
+        n2w_single(caps.get(0).unwrap().as_str().trim())
+    }).to_string();
+
+    let temp_text = text_mut.clone();
+    text_mut = RE_NUMBER_START.replace_all(&temp_text, |caps: &Captures| {
+        let negative = caps.get(1).is_some();
+        let num = caps.get(2).unwrap().as_str();
+        format!("{} ", num_to_words(num, negative))
+    }).to_string();
+
+    let temp_text2 = text_mut.clone();
+    text_mut = RE_NUMBER.replace_all(&temp_text2, |caps: &Captures| {
+        let prefix = caps.get(1).unwrap().as_str();
+        let negative = caps.get(2).is_some();
+        let num = caps.get(3).unwrap().as_str();
+
+        // Check if prefix is letter. If so, don't insert space after prefix if it might be an alphanumeric acronym part
+        // but the current regex RE_NUMBER uses (\D) which includes spaces.
+        if prefix.chars().all(|c| c.is_alphabetic()) && prefix.trim().len() == prefix.len() {
+             format!("{} {} ", prefix, num_to_words(num, negative))
+        } else {
+             format!("{} {} ", prefix, num_to_words(num, negative))
+        }
+    }).to_string();
+
+    text_mut
+}
+
+pub fn normalize_technical(text: &str) -> String {
+    RE_TECHNICAL.replace_all(text, |caps: &Captures| {
+        let orig = caps.get(0).unwrap().as_str();
+        let mut rest = orig;
+        let mut res = Vec::new();
+
+        if let Some(p_idx) = orig.to_lowercase().find("://") {
+            let protocol = &orig[..p_idx];
+            let p_norm = if (protocol.chars().all(|c: char| c.is_uppercase()) && protocol.len() <= 4) || protocol.len() <= 3 {
+                protocol.to_lowercase().chars().map(|c| c.to_string()).collect::<Vec<_>>().join(" ")
+            } else {
+                protocol.to_lowercase()
+            };
+            res.push(format!("__start_en__{}__end_en__", p_norm));
+            rest = &orig[p_idx + 3..];
+        } else if orig.starts_with('/') {
+            res.push("gạch".to_string());
+            rest = &orig[1..];
+        }
+
+        let mut segments = Vec::new();
+        let mut last_pos = 0;
+        for mat in RE_TECH_SPLIT.find_iter(rest) {
+            let mat = mat.unwrap();
+            segments.push(rest[last_pos..mat.start()].to_string());
+            segments.push(mat.as_str().to_string());
+            last_pos = mat.end();
+        }
+        if last_pos < rest.len() {
+            segments.push(rest[last_pos..].to_string());
+        }
+
+        let mut idx = 0;
+        while idx < segments.len() {
+            let s = &segments[idx];
+            if s.is_empty() {
+                idx += 1;
+                continue;
+            }
+
+            match s.as_str() {
+                "." => {
+                    let mut next_seg = "";
+                    for j in (idx + 1)..segments.len() {
+                        let sj = &segments[j];
+                        if !sj.is_empty() && !("./:?&=/_ -\\".contains(sj)) {
+                            next_seg = sj;
+                            break;
+                        }
+                    }
+                    if !next_seg.is_empty() && DOMAIN_SUFFIX_MAP.contains_key(next_seg.to_lowercase().as_str()) {
+                        res.push("chấm".to_string());
+                        res.push((*DOMAIN_SUFFIX_MAP.get(next_seg.to_lowercase().as_str()).unwrap()).to_string());
+                        idx += 1;
+                        while idx < segments.len() && (segments[idx].is_empty() || segments[idx].to_lowercase() != next_seg.to_lowercase()) {
+                            idx += 1;
+                        }
+                        idx += 1;
+                        continue;
+                    }
+                    res.push("chấm".to_string());
+                }
+                "/" | "\\" => res.push("gạch".to_string()),
+                "-" => res.push("gạch ngang".to_string()),
+                "_" => res.push("gạch dưới".to_string()),
+                ":" => res.push("hai chấm".to_string()),
+                "?" => res.push("hỏi".to_string()),
+                "&" => res.push("và".to_string()),
+                "=" => res.push("bằng".to_string()),
+                "#" => res.push("thăng".to_string()),
+                _ if DOMAIN_SUFFIX_MAP.contains_key(s.to_lowercase().as_str()) => {
+                    res.push((*DOMAIN_SUFFIX_MAP.get(s.to_lowercase().as_str()).unwrap()).to_string());
+                }
+                _ if s.chars().all(|c: char| c.is_alphanumeric() && c.is_ascii()) => {
+                    if s.chars().all(|c: char| c.is_ascii_digit()) {
+                        res.push(s.chars().map(|c: char| n2w_single(&c.to_string())).collect::<Vec<_>>().join(" "));
+                    } else {
+                        let sub_tokens: Vec<&str> = RE_ALPHANUM_SPLIT.find_iter(s).map(|m| m.unwrap().as_str()).collect();
+                        if sub_tokens.len() > 1 {
+                            for t in sub_tokens {
+                                if t.chars().all(|c: char| c.is_ascii_digit()) {
+                                    res.push(t.chars().map(|c: char| n2w_single(&c.to_string())).collect::<Vec<_>>().join(" "));
+                                } else {
+                                    let mut val = t.to_lowercase();
+                                    if (t.chars().all(|c: char| c.is_uppercase()) && t.len() <= 4) || t.len() <= 2 {
+                                        val = val.chars().map(|c| c.to_string()).collect::<Vec<_>>().join(" ");
+                                    }
+                                    res.push(format!("__start_en__{}__end_en__", val));
+                                }
+                            }
+                        } else {
+                            let mut val = s.to_lowercase();
+                            if (s.chars().all(|c: char| c.is_uppercase()) && s.len() <= 4) || s.len() <= 2 {
+                                val = val.chars().map(|c| c.to_string()).collect::<Vec<_>>().join(" ");
+                            }
+                            res.push(format!("__start_en__{}__end_en__", val));
+                        }
+                    }
+                }
+                _ => {
+                    for c in s.to_lowercase().chars() {
+                        if c.is_alphanumeric() {
+                            if c.is_ascii_digit() {
+                                res.push(n2w_single(&c.to_string()));
+                            } else {
+                                res.push((*VI_LETTER_NAMES.get(c.to_string().as_str()).unwrap_or(&c.to_string().as_str())).to_string());
+                            }
+                        } else {
+                            res.push(c.to_string());
+                        }
+                    }
+                }
+            }
+            idx += 1;
+        }
+        res.join(" ").replace("  ", " ").trim().to_string()
+    }).to_string()
+}
+
+pub fn normalize_emails(text: &str) -> String {
+    RE_EMAIL.replace_all(text, |caps: &Captures| {
+        let email = caps.get(0).unwrap().as_str();
+        let parts: Vec<&str> = email.split('@').collect();
+        if parts.len() != 2 { return email.to_string(); }
+
+        let user_part = parts[0];
+        let domain_part = parts[1];
+
+        fn norm_segment(s: &str) -> String {
+            if s.is_empty() { return String::new(); }
+            if s.chars().all(|c: char| c.is_ascii_digit()) { return n2w(s); }
+            if s.chars().all(|c: char| c.is_alphanumeric() && c.is_ascii()) {
+                let sub_tokens: Vec<&str> = RE_ALPHANUM_SPLIT.find_iter(s).map(|m| m.unwrap().as_str()).collect();
+                if sub_tokens.len() > 1 {
+                    let mut res_parts = Vec::new();
+                    for t in sub_tokens {
+                        if t.chars().all(|c: char| c.is_ascii_digit()) {
+                            res_parts.push(n2w(t));
+                        } else {
+                            res_parts.push(format!("__start_en__{}__end_en__", t.to_lowercase()));
+                        }
+                    }
+                    return res_parts.join(" ");
+                }
+                return format!("__start_en__{}__end_en__", s.to_lowercase());
+            }
+
+            let mut res = Vec::new();
+            for c in s.to_lowercase().chars() {
+                if c.is_alphanumeric() {
+                    if c.is_ascii_digit() {
+                        res.push(n2w_single(&c.to_string()));
+                    } else {
+                        res.push((*VI_LETTER_NAMES.get(c.to_string().as_str()).unwrap_or(&c.to_string().as_str())).to_string());
+                    }
+                } else {
+                    res.push(c.to_string());
+                }
+            }
+            res.join(" ")
+        }
+
+        fn process_part(p: &str, is_domain: bool) -> String {
+            let mut segments = Vec::new();
+            let mut last_pos = 0;
+            for mat in RE_EMAIL_SPLIT.find_iter(p) {
+                let mat = mat.unwrap();
+                segments.push(p[last_pos..mat.start()].to_string());
+                segments.push(mat.as_str().to_string());
+                last_pos = mat.end();
+            }
+            if last_pos < p.len() {
+                segments.push(p[last_pos..].to_string());
+            }
+
+            let mut res = Vec::new();
+            let mut idx = 0;
+            while idx < segments.len() {
+                let s = &segments[idx];
+                if s.is_empty() {
+                    idx += 1;
+                    continue;
+                }
+                if s == "." {
+                    if is_domain {
+                        let mut next_seg = "";
+                        let mut peek_idx = -1;
+                        for j in (idx + 1)..segments.len() {
+                            let sj = &segments[j];
+                            if !sj.is_empty() && !("._-+".contains(sj)) {
+                                next_seg = sj;
+                                peek_idx = j as i32;
+                                break;
+                            }
+                        }
+
+                        if !next_seg.is_empty() && DOMAIN_SUFFIX_MAP.contains_key(next_seg.to_lowercase().as_str()) {
+                            res.push("chấm".to_string());
+                            res.push((*DOMAIN_SUFFIX_MAP.get(next_seg.to_lowercase().as_str()).unwrap()).to_string());
+                            idx = peek_idx as usize + 1;
+                            continue;
+                        }
+                    }
+                    res.push("chấm".to_string());
+                } else if s == "_" { res.push("gạch dưới".to_string()); }
+                else if s == "-" { res.push("gạch ngang".to_string()); }
+                else if s == "+" { res.push("cộng".to_string()); }
+                else {
+                    res.push(norm_segment(s));
+                }
+                idx += 1;
+            }
+            res.join(" ")
+        }
+
+        let user_norm = process_part(user_part, false);
+        let domain_norm = if let Some(norm) = COMMON_EMAIL_DOMAINS.get(domain_part.to_lowercase().as_str()) {
+            (*norm).to_string()
+        } else {
+            process_part(domain_part, true)
+        };
+
+        format!("{} a còng {}", user_norm, domain_norm).replace("  ", " ").trim().to_string()
+    }).to_string()
+}
+
+pub fn normalize_slashes(text: &str) -> String {
+    RE_SLASH_NUMBER.replace_all(text, |caps: &Captures| {
+        let n1 = caps.get(1).unwrap().as_str();
+        let n2 = caps.get(2).unwrap().as_str();
+        if n1.len() > 2 || n1.parse::<i32>().unwrap_or(0) > 31 {
+            format!("{} xẹt {}", n2w(n1), n2w(n2))
+        } else {
+            format!("{} trên {}", n2w(n1), n2w(n2))
+        }
+    }).to_string()
+}
+
+pub fn expand_power_of_ten(text: &str) -> String {
+    let mut text = RE_POWER_OF_TEN_EXPLICIT.replace_all(text, |caps: &Captures| {
+        let base = caps.get(1).unwrap().as_str();
+        let exp = caps.get(2).unwrap().as_str();
+        let base_norm = normalize_others(base);
+        let exp_val = exp.replace('+', "");
+        let exp_norm = if exp_val.starts_with('-') {
+            format!("trừ {}", n2w(&exp_val[1..]))
+        } else {
+            n2w(&exp_val)
+        };
+        format!(" {} nhân mười mũ {} ", base_norm.trim(), exp_norm)
+    }).to_string();
+
+    text = RE_POWER_OF_TEN_IMPLICIT.replace_all(&text, |caps: &Captures| {
+        let exp = caps.get(1).unwrap().as_str();
+        let exp_val = exp.replace('+', "");
+        let exp_norm = if exp_val.starts_with('-') {
+            format!("trừ {}", n2w(&exp_val[1..]))
+        } else {
+            n2w(&exp_val)
+        };
+        format!("mười mũ {}", exp_norm)
+    }).to_string();
+
+    text
+}
+
+pub fn normalize_others(text: &str) -> String {
+    let mut text = RE_ACRONYMS_EXCEPTIONS.replace_all(text, |caps: &Captures| {
+        (*COMBINED_EXCEPTIONS.get(caps.get(0).unwrap().as_str()).unwrap()).to_string()
+    }).to_string();
+
+    text = normalize_slashes(&text);
+    text = RE_DOMAIN_SUFFIXES.replace_all(&text, |caps: &Captures| {
+        format!(" chấm {}", DOMAIN_SUFFIX_MAP.get(caps.get(1).unwrap().as_str().to_lowercase().as_str()).unwrap_or(&caps.get(1).unwrap().as_str()))
+    }).to_string();
+
+    text = expand_roman(&text);
+    text = RE_LETTER.replace_all(&text, |caps: &Captures| {
+        let prefix = caps.get(1).unwrap().as_str();
+        let c = caps.get(3).unwrap().as_str().to_lowercase();
+        if let Some(&name) = VI_LETTER_NAMES.get(c.as_str()) {
+            format!("{} {} ", prefix, name)
+        } else {
+            caps.get(0).unwrap().as_str().to_string()
+        }
+    }).to_string();
+
+    text = expand_alphanumeric(&text);
+    text = expand_prime(&text);
+    text = expand_unit_powers(&text);
+    text = RE_CLEAN_QUOTES.replace_all(&text, "").to_string();
+    text = RE_CLEAN_QUOTES_EDGES.replace_all(&text, "$1 $2").to_string();
+    text = expand_symbols(&text);
+    text = RE_BRACKETS.replace_all(&text, ", $1, ").to_string();
+    text = RE_STRIP_BRACKETS.replace_all(&text, " ").to_string();
+    text = expand_temperatures(&text);
+    text = normalize_acronyms(&text);
+
+    text = RE_VERSION.replace_all(&text, |caps: &Captures| {
+        let v = caps.get(1).unwrap().as_str();
+        let parts: Vec<String> = v.split('.').map(|s| n2w_single(s)).collect();
+        parts.join(" chấm ")
+    }).to_string();
+
+    text = RE_COLON_SEMICOLON.replace_all(&text, ",").to_string();
+    RE_CLEAN_OTHERS.replace_all(&text, " ").to_string()
+}
+
+pub fn cleanup_whitespace(text: &str) -> String {
+    let mut text = RE_EXTRA_SPACES.replace_all(text, " ").to_string();
+    text = RE_EXTRA_COMMAS.replace_all(&text, ",").to_string();
+    text = RE_COMMA_BEFORE_PUNCT.replace_all(&text, "$1").to_string();
+    text = RE_SPACE_BEFORE_PUNCT.replace_all(&text, "$1").to_string();
+    text = RE_MISSING_SPACE_AFTER_PUNCT.replace_all(&text, "$1 ").to_string();
+    text.trim().trim_matches(',').to_string()
+}
+
+pub fn clean_vietnamese_text(text: &str) -> String {
+    let mut mask_map = HashMap::new();
+    let mut text_mut = text.to_string();
+
+    text_mut = RE_ENTOKEN.replace_all(&text_mut, |caps: &Captures| {
+        let orig = caps.get(0).unwrap().as_str();
+        let idx = mask_map.len();
+        let mut mask = format!("mask{:0>4}mask", idx);
+        let trans: Vec<(char, char)> = "0123456789".chars().zip("abcdefghij".chars()).collect();
+        for (from, to) in trans {
+            mask = mask.replace(from, to.to_string().as_str());
+        }
+        mask_map.insert(mask.clone(), orig.to_string());
+        mask
+    }).to_string();
+
+    let mut temp_text = text_mut.clone();
+    text_mut = RE_EMAIL.replace_all(&temp_text, |caps: &Captures| {
+        let orig = caps.get(0).unwrap().as_str();
+        let normed = normalize_emails(orig);
+        let idx = mask_map.len();
+        let mut mask = format!("mask{:0>4}mask", idx);
+        let trans: Vec<(char, char)> = "0123456789".chars().zip("abcdefghij".chars()).collect();
+        for (from, to) in trans {
+            mask = mask.replace(from, to.to_string().as_str());
+        }
+        mask_map.insert(mask.clone(), normed);
+        mask
+    }).to_string();
+
+    temp_text = text_mut.clone();
+    text_mut = RE_TECHNICAL.replace_all(&temp_text, |caps: &Captures| {
+        let orig = caps.get(0).unwrap().as_str();
+        if let Some(normed_ex) = COMBINED_EXCEPTIONS.get(orig) {
+            let idx = mask_map.len();
+            let mut mask = format!("mask{:0>4}mask", idx);
+            let trans: Vec<(char, char)> = "0123456789".chars().zip("abcdefghij".chars()).collect();
+            for (from, to) in trans {
+                mask = mask.replace(from, to.to_string().as_str());
+            }
+            mask_map.insert(mask.clone(), normed_ex.to_string());
+            return mask;
+        }
+        let normed = normalize_technical(orig);
+        let idx = mask_map.len();
+        let mut mask = format!("mask{:0>4}mask", idx);
+        let trans: Vec<(char, char)> = "0123456789".chars().zip("abcdefghij".chars()).collect();
+        for (from, to) in trans {
+            mask = mask.replace(from, to.to_string().as_str());
+        }
+        mask_map.insert(mask.clone(), normed);
+        mask
+    }).to_string();
+
+    text_mut = expand_power_of_ten(&text_mut);
+    text_mut = expand_abbreviations(&text_mut);
+    text_mut = normalize_date(&text_mut);
+    text_mut = normalize_time(&text_mut);
+
+    // Range handling
+    static RE_RANGE: Lazy<Regex> = Lazy::new(|| Regex::new(r"(\d+(?:[,.]\d+)?)\s*[–\-—]\s*(\d+(?:[,.]\d+)?)").unwrap());
+    static RE_DASH_TO_COMMA: Lazy<Regex> = Lazy::new(|| Regex::new(r"(?<= )[–\-—](?= )").unwrap());
+    static RE_TO_SANG: Lazy<Regex> = Lazy::new(|| Regex::new(r"\s*(?:->|=>)\s*").unwrap());
+
+    temp_text = text_mut.clone();
+    text_mut = RE_RANGE.replace_all(&temp_text, |caps: &Captures| {
+        let n1 = caps.get(1).unwrap().as_str().replace(',', "").replace('.', "");
+        let n2 = caps.get(2).unwrap().as_str().replace(',', "").replace('.', "");
+        if (n1.len() as i32 - n2.len() as i32).abs() <= 1 {
+            format!("{} đến {}", caps.get(1).unwrap().as_str(), caps.get(2).unwrap().as_str())
+        } else {
+            format!("{} {}", caps.get(1).unwrap().as_str(), caps.get(2).unwrap().as_str())
+        }
+    }).to_string();
+    temp_text = text_mut.clone();
+    text_mut = RE_DASH_TO_COMMA.replace_all(&temp_text, ",").to_string();
+    temp_text = text_mut.clone();
+    text_mut = RE_TO_SANG.replace_all(&temp_text, " sang ").to_string();
+
+    temp_text = text_mut.clone();
+    text_mut = RE_SCIENTIFIC.replace_all(&temp_text, |caps: &Captures| expand_number_with_sep(caps.get(1).unwrap().as_str())).to_string();
+    text_mut = expand_compound_units(&text_mut);
+    text_mut = expand_measurement_currency(&text_mut);
+
+    // English style numbers fix
+    static RE_ENGLISH_STYLE_NUMBERS: Lazy<Regex> = Lazy::new(|| Regex::new(r"\b\d{1,3}(?:,\d{3})+(?:\.\d+)?\b").unwrap());
+    temp_text = text_mut.clone();
+    text_mut = RE_ENGLISH_STYLE_NUMBERS.replace_all(&temp_text, |caps: &Captures| {
+        let val = caps.get(0).unwrap().as_str();
+        if val.contains(',') && val.contains('.') {
+            val.replace(',', "").replace('.', ",")
+        } else {
+            val.replace(',', "")
+        }
+    }).to_string();
+
+    temp_text = text_mut.clone();
+    text_mut = RE_MULTI_COMMA.replace_all(&temp_text, |caps: &Captures| {
+        let s = caps.get(1).unwrap().as_str();
+        let parts: Vec<String> = s.split(',').map(|p| {
+            p.chars().map(|c| n2w_single(&c.to_string())).collect::<Vec<_>>().join(" ")
+        }).collect();
+        parts.join(" phẩy ")
+    }).to_string();
+
+    temp_text = text_mut.clone();
+    text_mut = RE_FLOAT_WITH_COMMA.replace_all(&temp_text, |caps: &Captures| {
+        let int_part = n2w(&caps.get(1).unwrap().as_str().replace('.', ""));
+        let dec_part = caps.get(2).unwrap().as_str().trim_end_matches('0');
+        let mut res = if dec_part.is_empty() {
+            int_part
+        } else {
+            format!("{} phẩy {}", int_part, n2w_single(dec_part))
+        };
+        if caps.get(3).is_some() {
+            res.push_str(" phần trăm");
+        }
+        format!(" {} ", res)
+    }).to_string();
+
+    temp_text = text_mut.clone();
+    text_mut = RE_STRIP_DOT_SEP.replace_all(&temp_text, |caps: &Captures| {
+        caps.get(0).unwrap().as_str().replace('.', "")
+    }).to_string();
+
+    text_mut = normalize_others(&text_mut);
+
+    // Mask English tags before normalizing other numbers
+    temp_text = text_mut.clone();
+    text_mut = RE_INTERNAL_EN_TAG.replace_all(&temp_text, |caps: &Captures| {
+        let orig = caps.get(0).unwrap().as_str();
+        let idx = mask_map.len();
+        let mut mask = format!("mask{:0>4}mask", idx);
+        let trans: Vec<(char, char)> = "0123456789".chars().zip("abcdefghij".chars()).collect();
+        for (from, to) in trans {
+            mask = mask.replace(from, to.to_string().as_str());
+        }
+        mask_map.insert(mask.clone(), orig.to_string());
+        mask
+    }).to_string();
+
+    text_mut = normalize_number_vi(&text_mut);
+
+    text_mut = expand_standalone_letters(&text_mut);
+
+    while let Ok(Some(_)) = RE_DOT_BETWEEN_DIGITS.captures(&text_mut) {
+        temp_text = text_mut.clone();
+        text_mut = RE_DOT_BETWEEN_DIGITS.replace_all(&temp_text, "$1 chấm $2").to_string();
+    }
+
+    for (mask, original) in mask_map {
+        text_mut = text_mut.replace(&mask, &original);
+        text_mut = text_mut.replace(&mask.to_lowercase(), &original);
+    }
+
+    text_mut = text_mut.replace("__start_en__", "<en>").replace("__end_en__", "</en>").replace('_', " ");
+    cleanup_whitespace(&text_mut).to_lowercase()
+}

--- a/src/normalizer/mod.rs
+++ b/src/normalizer/mod.rs
@@ -1,0 +1,56 @@
+pub mod vi_resources;
+pub mod num2vi;
+pub mod cleaner;
+
+use unicode_normalization::UnicodeNormalization;
+
+pub struct Normalizer {
+}
+
+impl Normalizer {
+    pub fn new() -> Self {
+        Self {}
+    }
+
+    pub fn normalize(&self, text: &str) -> String {
+        if text.is_empty() {
+            return String::new();
+        }
+
+        // Pre-normalization: Ensure NFC format for Vietnamese characters
+        let text_nfc: String = text.nfc().collect();
+
+        // 1. Detect and protect EN tags (matches Python's Normalizer.normalize)
+        let mut en_contents = Vec::new();
+        let mut text_masked = text_nfc;
+
+        static RE_EN: Lazy<fancy_regex::Regex> = Lazy::new(|| fancy_regex::Regex::new(r"(?i)<en>.*?</en>").unwrap());
+
+        while let Ok(Some(mat)) = RE_EN.find(&text_masked) {
+            let start = mat.start();
+            let end = mat.end();
+            let content = mat.as_str().to_string();
+            let placeholder = format!("ENTOKEN{}", en_contents.len());
+            en_contents.push(content);
+            text_masked.replace_range(start..end, &placeholder);
+        }
+
+        // 2. Core Normalization
+        let mut normalized = cleaner::clean_vietnamese_text(&text_masked);
+
+        // 3. Final cleanup - preserve newlines
+        normalized = normalized.to_lowercase();
+        normalized = cleaner::cleanup_whitespace(&normalized);
+
+        // 4. Restore EN tags
+        for (idx, content) in en_contents.iter().enumerate() {
+            let placeholder = format!("entoken{}", idx);
+            normalized = normalized.replace(&placeholder, content);
+        }
+
+        // Final whitespace cleanup
+        cleaner::cleanup_whitespace(&normalized)
+    }
+}
+
+use once_cell::sync::Lazy;

--- a/src/normalizer/num2vi.rs
+++ b/src/normalizer/num2vi.rs
@@ -1,0 +1,178 @@
+use once_cell::sync::Lazy;
+use std::collections::HashMap;
+
+pub const UNITS: [&str; 10] = ["không", "một", "hai", "ba", "bốn", "năm", "sáu", "bảy", "tám", "chín"];
+
+pub fn pre_process_n2w(number: &str) -> Option<String> {
+    let clean: String = number.chars().filter(|c| c.is_ascii_digit()).collect();
+    if clean.is_empty() {
+        None
+    } else {
+        Some(clean)
+    }
+}
+
+pub fn process_n2w_single(numbers: &str, buffer: &mut String) {
+    let mut first = true;
+    for c in numbers.chars() {
+        if let Some(digit) = c.to_digit(10) {
+            if !first {
+                buffer.push(' ');
+            }
+            buffer.push_str(UNITS[digit as usize]);
+            first = false;
+        }
+    }
+}
+
+pub fn n2w_hundreds(numbers: &str, buffer: &mut String, is_group: bool) {
+    if numbers.is_empty() || numbers == "000" {
+        return;
+    }
+
+    let n = format!("{:0>3}", numbers);
+    let h_digit = n.chars().nth(0).unwrap().to_digit(10).unwrap() as usize;
+    let t_digit = n.chars().nth(1).unwrap().to_digit(10).unwrap() as usize;
+    let u_digit = n.chars().nth(2).unwrap().to_digit(10).unwrap() as usize;
+
+    let mut added = false;
+
+    // Hundreds
+    if h_digit != 0 {
+        buffer.push_str(UNITS[h_digit]);
+        buffer.push_str(" trăm");
+        added = true;
+    } else if is_group {
+        buffer.push_str("không trăm");
+        added = true;
+    }
+
+    // Tens
+    if t_digit == 0 {
+        if u_digit != 0 && (h_digit != 0 || is_group) {
+            if added { buffer.push(' '); }
+            buffer.push_str("lẻ");
+            added = true;
+        }
+    } else if t_digit == 1 {
+        if added { buffer.push(' '); }
+        buffer.push_str("mười");
+        added = true;
+    } else {
+        if added { buffer.push(' '); }
+        buffer.push_str(UNITS[t_digit]);
+        buffer.push_str(" mươi");
+        added = true;
+    }
+
+    // Units
+    if u_digit != 0 {
+        if added { buffer.push(' '); }
+        if u_digit == 1 && t_digit > 1 {
+            buffer.push_str("mốt");
+        } else if u_digit == 5 && t_digit != 0 {
+            buffer.push_str("lăm");
+        } else {
+            buffer.push_str(UNITS[u_digit]);
+        }
+    }
+}
+
+pub fn n2w_large_number(numbers: &str, buffer: &mut String) {
+    let numbers = numbers.trim_start_matches('0');
+    if numbers.is_empty() {
+        buffer.push_str(UNITS[0]);
+        return;
+    }
+
+    let n_len = numbers.len();
+    let mut groups = Vec::new();
+    let mut i = n_len as i32;
+    while i > 0 {
+        let start = std::cmp::max(0, i - 3) as usize;
+        let end = i as usize;
+        groups.push(&numbers[start..end]);
+        i -= 3;
+    }
+
+    let suffixes = ["", " nghìn", " triệu", " tỷ"];
+    let mut parts = Vec::new();
+
+    for (idx, &group) in groups.iter().enumerate() {
+        if group == "000" {
+            continue;
+        }
+
+        let mut group_buf = String::new();
+        // is_group should be true if it's not the most significant group
+        n2w_hundreds(group, &mut group_buf, idx < groups.len() - 1);
+
+        if !group_buf.is_empty() {
+            let suffix_idx = idx % 3;
+            let ty_count = idx / 3;
+
+            let mut full_suffix = String::new();
+            if suffix_idx < suffixes.len() {
+                full_suffix.push_str(suffixes[suffix_idx]);
+            }
+            for _ in 0..ty_count {
+                full_suffix.push_str(" tỷ");
+            }
+
+            group_buf.push_str(&full_suffix);
+            parts.push(group_buf);
+        }
+    }
+
+    if parts.is_empty() {
+        buffer.push_str(UNITS[0]);
+        return;
+    }
+
+    parts.reverse();
+    for (i, p) in parts.iter().enumerate() {
+        if i > 0 {
+            buffer.push(' ');
+        }
+        buffer.push_str(p);
+    }
+}
+
+pub fn n2w(number: &str) -> String {
+    let mut buffer = String::new();
+    let clean_opt = pre_process_n2w(number);
+    if clean_opt.is_none() {
+        return number.to_string();
+    }
+    let clean_number = clean_opt.unwrap();
+
+    if clean_number.len() == 2 && clean_number.starts_with('0') {
+        buffer.push_str("không ");
+        let digit = clean_number.chars().nth(1).unwrap().to_digit(10).unwrap() as usize;
+        buffer.push_str(UNITS[digit]);
+        return buffer;
+    }
+
+    n2w_large_number(&clean_number, &mut buffer);
+    buffer.trim().to_string()
+}
+
+pub fn n2w_single(number: &str) -> String {
+    let mut input = number;
+    let mut owned_input;
+    if input.starts_with("+84") {
+        owned_input = "0".to_string();
+        owned_input.push_str(&input[3..]);
+        input = &owned_input;
+    }
+
+    let clean_opt = pre_process_n2w(input);
+    if clean_opt.is_none() {
+        return number.to_string();
+    }
+    let clean_number = clean_opt.unwrap();
+
+    let mut buffer = String::new();
+    process_n2w_single(&clean_number, &mut buffer);
+    buffer
+}

--- a/src/normalizer/vi_resources.rs
+++ b/src/normalizer/vi_resources.rs
@@ -1,0 +1,196 @@
+use once_cell::sync::Lazy;
+use std::collections::{HashMap, HashSet};
+
+pub static VI_LETTER_NAMES: Lazy<HashMap<String, &'static str>> = Lazy::new(|| {
+    let mut m = HashMap::new();
+    m.insert("a".to_string(), "a"); m.insert("b".to_string(), "bê"); m.insert("c".to_string(), "xê");
+    m.insert("d".to_string(), "đê"); m.insert("đ".to_string(), "đê"); m.insert("e".to_string(), "e");
+    m.insert("ê".to_string(), "ê"); m.insert("f".to_string(), "ép"); m.insert("g".to_string(), "gờ");
+    m.insert("h".to_string(), "hát"); m.insert("i".to_string(), "i"); m.insert("j".to_string(), "giây");
+    m.insert("k".to_string(), "ca"); m.insert("l".to_string(), "lờ"); m.insert("m".to_string(), "mờ");
+    m.insert("n".to_string(), "nờ"); m.insert("o".to_string(), "o"); m.insert("ô".to_string(), "ô");
+    m.insert("ơ".to_string(), "ơ"); m.insert("p".to_string(), "pê"); m.insert("q".to_string(), "qui");
+    m.insert("r".to_string(), "rờ"); m.insert("s".to_string(), "ét"); m.insert("t".to_string(), "tê");
+    m.insert("u".to_string(), "u"); m.insert("ư".to_string(), "ư"); m.insert("v".to_string(), "vê");
+    m.insert("w".to_string(), "đắp liu"); m.insert("x".to_string(), "ích"); m.insert("y".to_string(), "y");
+    m.insert("z".to_string(), "dét");
+    m
+});
+
+pub static COMMON_EMAIL_DOMAINS: Lazy<HashMap<String, &'static str>> = Lazy::new(|| {
+    let mut m = HashMap::new();
+    m.insert("gmail.com".to_string(), "__start_en__gmail__end_en__ chấm com");
+    m.insert("yahoo.com".to_string(), "__start_en__yahoo__end_en__ chấm com");
+    m.insert("yahoo.com.vn".to_string(), "__start_en__yahoo__end_en__ chấm com chấm __start_en__v n__end_en__");
+    m.insert("outlook.com".to_string(), "__start_en__outlook__end_en__ chấm com");
+    m.insert("hotmail.com".to_string(), "__start_en__hotmail__end_en__ chấm com");
+    m.insert("icloud.com".to_string(), "__start_en__icloud__end_en__ chấm com");
+    m.insert("fpt.vn".to_string(), "__start_en__f p t__end_en__ chấm __start_en__v n__end_en__");
+    m.insert("fpt.com.vn".to_string(), "__start_en__f p t__end_en__ chấm com chấm __start_en__v n__end_en__");
+    m
+});
+
+pub static MEASUREMENT_KEY_VI: Lazy<HashMap<String, &'static str>> = Lazy::new(|| {
+    let mut m = HashMap::new();
+    m.insert("km".to_string(), "ki lô mét"); m.insert("dm".to_string(), "đê xi mét");
+    m.insert("cm".to_string(), "xen ti mét"); m.insert("mm".to_string(), "mi li mét");
+    m.insert("nm".to_string(), "na nô mét"); m.insert("µm".to_string(), "mic rô mét");
+    m.insert("μm".to_string(), "mic rô mét"); m.insert("m".to_string(), "mét");
+    m.insert("kg".to_string(), "ki lô gam"); m.insert("g".to_string(), "gam");
+    m.insert("mg".to_string(), "mi li gam"); m.insert("km2".to_string(), "ki lô mét vuông");
+    m.insert("m2".to_string(), "mét vuông"); m.insert("cm2".to_string(), "xen ti mét vuông");
+    m.insert("mm2".to_string(), "mi li mét vuông"); m.insert("ha".to_string(), "héc ta");
+    m.insert("km3".to_string(), "ki lô mét khối"); m.insert("m3".to_string(), "mét khối");
+    m.insert("cm3".to_string(), "xen ti mét khối"); m.insert("mm3".to_string(), "mi li mét khối");
+    m.insert("l".to_string(), "lít"); m.insert("dl".to_string(), "đê xi lít");
+    m.insert("ml".to_string(), "mi li lít"); m.insert("hl".to_string(), "héc tô lít");
+    m.insert("kw".to_string(), "ki lô oát"); m.insert("mw".to_string(), "mê ga oát");
+    m.insert("gw".to_string(), "gi ga oát"); m.insert("kwh".to_string(), "ki lô oát giờ");
+    m.insert("mwh".to_string(), "mê ga oát giờ"); m.insert("wh".to_string(), "oát giờ");
+    m.insert("hz".to_string(), "héc"); m.insert("khz".to_string(), "ki lô héc");
+    m.insert("mhz".to_string(), "mê ga héc"); m.insert("ghz".to_string(), "gi ga héc");
+    m.insert("pa".to_string(), "__start_en__pascal__end_en__");
+    m.insert("kpa".to_string(), "__start_en__kilopascal__end_en__");
+    m.insert("mpa".to_string(), "__start_en__megapascal__end_en__");
+    m.insert("bar".to_string(), "__start_en__bar__end_en__");
+    m.insert("mbar".to_string(), "__start_en__millibar__end_en__");
+    m.insert("atm".to_string(), "__start_en__atmosphere__end_en__");
+    m.insert("psi".to_string(), "__start_en__p s i__end_en__");
+    m.insert("j".to_string(), "__start_en__joule__end_en__");
+    m.insert("kj".to_string(), "__start_en__kilojoule__end_en__");
+    m.insert("cal".to_string(), "__start_en__calorie__end_en__");
+    m.insert("kcal".to_string(), "__start_en__kilocalorie__end_en__");
+    m.insert("h".to_string(), "giờ"); m.insert("p".to_string(), "phút");
+    m.insert("s".to_string(), "giây"); m.insert("sqm".to_string(), "mét vuông");
+    m.insert("cum".to_string(), "mét khối"); m.insert("gb".to_string(), "__start_en__gigabyte__end_en__");
+    m.insert("mb".to_string(), "__start_en__megabyte__end_en__");
+    m.insert("kb".to_string(), "__start_en__kilobyte__end_en__");
+    m.insert("tb".to_string(), "__start_en__terabyte__end_en__");
+    m.insert("db".to_string(), "__start_en__decibel__end_en__");
+    m.insert("oz".to_string(), "__start_en__ounce__end_en__");
+    m.insert("lb".to_string(), "__start_en__pound__end_en__");
+    m.insert("lbs".to_string(), "__start_en__pounds__end_en__");
+    m.insert("ft".to_string(), "__start_en__feet__end_en__");
+    m.insert("in".to_string(), "__start_en__inch__end_en__");
+    m.insert("dpi".to_string(), "__start_en__d p i__end_en__");
+    m.insert("ph".to_string(), "pê hát");
+    m.insert("pH".to_string(), "pê hát"); // Added mixed case key for pH
+    m.insert("gbps".to_string(), "__start_en__gigabits per second__end_en__");
+    m.insert("mbps".to_string(), "__start_en__megabits per second__end_en__");
+    m.insert("kbps".to_string(), "__start_en__kilobits per second__end_en__");
+    m.insert("gallon".to_string(), "__start_en__gallon__end_en__");
+    m.insert("mol".to_string(), "mol"); m.insert("ms".to_string(), "mi li giây");
+    m.insert("M".to_string(), "triệu");
+    m
+});
+
+pub static CURRENCY_KEY: Lazy<HashMap<String, &'static str>> = Lazy::new(|| {
+    let mut m = HashMap::new();
+    m.insert("usd".to_string(), "__start_en__u s d__end_en__"); m.insert("vnd".to_string(), "đồng");
+    m.insert("đ".to_string(), "đồng"); m.insert("v n d".to_string(), "đồng");
+    m.insert("v n đ".to_string(), "đồng"); m.insert("€".to_string(), "__start_en__euro__end_en__");
+    m.insert("euro".to_string(), "__start_en__euro__end_en__"); m.insert("eur".to_string(), "__start_en__euro__end_en__");
+    m.insert("¥".to_string(), "yên"); m.insert("yên".to_string(), "yên");
+    m.insert("jpy".to_string(), "yên"); m.insert("%".to_string(), "phần trăm");
+    m
+});
+
+pub static ACRONYMS_EXCEPTIONS_VI: Lazy<HashMap<String, &'static str>> = Lazy::new(|| {
+    let mut m = HashMap::new();
+    m.insert("CĐV".to_string(), "cổ động viên"); m.insert("HĐND".to_string(), "hội đồng nhân dân");
+    m.insert("HĐQT".to_string(), "hội đồng quản trị"); m.insert("TAND".to_string(), "tòa án nhân dân");
+    m.insert("BHXH".to_string(), "bảo hiểm xã hội"); m.insert("BHTN".to_string(), "bảo hiểm thất nghiệp");
+    m.insert("TP.HCM".to_string(), "thành phố hồ chí minh"); m.insert("VN".to_string(), "việt nam");
+    m.insert("UBND".to_string(), "uỷ ban nhân dân"); m.insert("TP".to_string(), "thành phố");
+    m.insert("HCM".to_string(), "hồ chí minh"); m.insert("HN".to_string(), "hà nội");
+    m.insert("BTC".to_string(), "ban tổ chức"); m.insert("CLB".to_string(), "câu lạc bộ");
+    m.insert("HTX".to_string(), "hợp tác xã"); m.insert("NXB".to_string(), "nhà xuất bản");
+    m.insert("TW".to_string(), "trung ương"); m.insert("CSGT".to_string(), "cảnh sát giao thông");
+    m.insert("LHQ".to_string(), "liên hợp quốc"); m.insert("THCS".to_string(), "trung học cơ sở");
+    m.insert("THPT".to_string(), "trung học phổ thông"); m.insert("ĐH".to_string(), "đại học");
+    m.insert("HLV".to_string(), "huấn luyện viên"); m.insert("GS".to_string(), "giáo sư");
+    m.insert("TS".to_string(), "tiến sĩ"); m.insert("TNHH".to_string(), "trách nhiệm hữu hạn");
+    m.insert("VĐV".to_string(), "vận động viên"); m.insert("TPHCM".to_string(), "thành phố hồ chí minh");
+    m.insert("PGS".to_string(), "phó giáo sư"); m.insert("SP500".to_string(), "ét pê năm trăm");
+    m.insert("PGS.TS".to_string(), "phó giáo sư tiến sĩ"); m.insert("GS.TS".to_string(), "giáo sư tiến sĩ");
+    m.insert("ThS".to_string(), "thạc sĩ"); m.insert("BS".to_string(), "bác sĩ");
+    m.insert("UAE".to_string(), "u a e"); m.insert("CUDA".to_string(), "cu đa");
+    m
+});
+
+pub static TECHNICAL_TERMS: Lazy<HashMap<String, &'static str>> = Lazy::new(|| {
+    let mut m = HashMap::new();
+    m.insert("JSON".to_string(), "__start_en__j son__end_en__"); m.insert("VRAM".to_string(), "__start_en__v ram__end_en__");
+    m.insert("NVIDIA".to_string(), "__start_en__n v d a__end_en__"); m.insert("VN-Index".to_string(), "__start_en__v n__end_en__ index");
+    m.insert("MS DOS".to_string(), "__start_en__m s dos__end_en__"); m.insert("MS-DOS".to_string(), "__start_en__m s dos__end_en__");
+    m.insert("B2B".to_string(), "__start_en__b two b__end_en__"); m.insert("MI5".to_string(), "__start_en__m i five__end_en__");
+    m.insert("MI6".to_string(), "__start_en__m i six__end_en__"); m.insert("2FA".to_string(), "__start_en__two f a__end_en__");
+    m.insert("TX-0".to_string(), "__start_en__t x zero__end_en__"); m.insert("IPv6".to_string(), "__start_en__i p v__end_en__ sáu");
+    m.insert("IPv4".to_string(), "__start_en__i p v__end_en__ bốn");
+    m
+});
+
+pub static DOMAIN_SUFFIX_MAP: Lazy<HashMap<String, &'static str>> = Lazy::new(|| {
+    let mut m = HashMap::new();
+    m.insert("com".to_string(), "com"); m.insert("vn".to_string(), "__start_en__v n__end_en__");
+    m.insert("net".to_string(), "nét"); m.insert("org".to_string(), "o rờ gờ");
+    m.insert("edu".to_string(), "__start_en__edu__end_en__"); m.insert("gov".to_string(), "gờ o vê");
+    m.insert("io".to_string(), "__start_en__i o__end_en__"); m.insert("biz".to_string(), "biz");
+    m.insert("info".to_string(), "info");
+    m
+});
+
+pub static CURRENCY_SYMBOL_MAP: Lazy<HashMap<String, &'static str>> = Lazy::new(|| {
+    let mut m = HashMap::new();
+    m.insert("$".to_string(), "__start_en__u s d__end_en__"); m.insert("€".to_string(), "__start_en__euro__end_en__");
+    m.insert("¥".to_string(), "yên"); m.insert("£".to_string(), "__start_en__pound__end_en__");
+    m.insert("₩".to_string(), "won");
+    m
+});
+
+pub static ROMAN_NUMERALS: Lazy<HashMap<char, i32>> = Lazy::new(|| {
+    let mut m = HashMap::new();
+    m.insert('I', 1); m.insert('V', 5); m.insert('X', 10); m.insert('L', 50);
+    m.insert('C', 100); m.insert('D', 500); m.insert('M', 1000);
+    m
+});
+
+pub static ABBRS: Lazy<HashMap<String, &'static str>> = Lazy::new(|| {
+    let mut m = HashMap::new();
+    m.insert("v.v".to_string(), " vân vân"); m.insert("v/v".to_string(), " về việc");
+    m.insert("đ/c".to_string(), "địa chỉ");
+    m
+});
+
+pub static SYMBOLS_MAP: Lazy<HashMap<char, &'static str>> = Lazy::new(|| {
+    let mut m = HashMap::new();
+    m.insert('&', " và "); m.insert('+', " cộng "); m.insert('=', " bằng ");
+    m.insert('#', " thăng "); m.insert('>', " lớn hơn "); m.insert('<', " nhỏ hơn ");
+    m.insert('≥', " lớn hơn hoặc bằng "); m.insert('≤', " nhỏ hơn hoặc bằng ");
+    m.insert('±', " cộng trừ "); m.insert('≈', " xấp xỉ "); m.insert('/', " trên ");
+    m.insert('→', " đến "); m.insert('÷', " chia "); m.insert('*', " sao ");
+    m.insert('×', " nhân "); m.insert('^', " mũ "); m.insert('~', " khoảng ");
+    m
+});
+
+pub static WORD_LIKE_ACRONYMS: Lazy<HashSet<&'static str>> = Lazy::new(|| {
+    let mut s = HashSet::new();
+    s.insert("UNESCO"); s.insert("NASA"); s.insert("NATO"); s.insert("ASEAN");
+    s.insert("OPEC"); s.insert("SARS"); s.insert("FIFA"); s.insert("UNIC");
+    s.insert("RAM"); s.insert("VRAM"); s.insert("COVID"); s.insert("IELTS");
+    s.insert("STEM"); s.insert("SWAT"); s.insert("SEAL"); s.insert("WASP");
+    s.insert("COBOL"); s.insert("BASIC"); s.insert("OLED"); s.insert("COVAX");
+    s.insert("BRICS"); s.insert("APEC"); s.insert("VUCA"); s.insert("PERMA");
+    s.insert("DINK"); s.insert("MENA"); s.insert("EPIC"); s.insert("OASIS");
+    s.insert("BASE"); s.insert("DART"); s.insert("IDEA"); s.insert("CHAOS");
+    s.insert("SMART"); s.insert("FANG"); s.insert("BLEU"); s.insert("REST");
+    s.insert("ERROR"); s.insert("SELECT"); s.insert("FROM"); s.insert("WHERE");
+    s
+});
+
+pub static COMBINED_EXCEPTIONS: Lazy<HashMap<String, &'static str>> = Lazy::new(|| {
+    let mut m = HashMap::new();
+    for (k, v) in ACRONYMS_EXCEPTIONS_VI.iter() { m.insert(k.clone(), *v); }
+    for (k, v) in TECHNICAL_TERMS.iter() { m.insert(k.clone(), *v); }
+    m
+});

--- a/uv.lock
+++ b/uv.lock
@@ -107,7 +107,7 @@ wheels = [
 
 [[package]]
 name = "sea-g2p"
-version = "0.5.5"
+version = "0.5.6"
 source = { editable = "." }
 
 [package.optional-dependencies]


### PR DESCRIPTION
Di chuyển toàn bộ Normalizer sang Rust để giảm chi phí chuyển đổi (Internal Overhead). 
Sử dụng thuật toán Aho-Corasick cho phần viết tắt và ký hiệu để tối ưu hóa việc tìm kiếm và thay thế.
Viết lại logic num2vi bằng cơ chế Lazy Lookup và sử dụng duy nhất một Buffer để giảm thiểu cấp phát bộ nhớ.
Tích hợp toàn bộ Pipeline (Normalize + G2P) chạy trực tiếp trong Rust, chỉ gọi từ Python một lần duy nhất.

---
*PR created automatically by Jules for task [17609260354840163292](https://jules.google.com/task/17609260354840163292) started by @pnnbao97*